### PR TITLE
fix: status timestamp type

### DIFF
--- a/webhooks/models.go
+++ b/webhooks/models.go
@@ -212,6 +212,7 @@ type (
 	// InteractiveType represent an item sent to user. It can be a reply button
 	// (ButtonReply) or a list reply containing a list of items (ListReply).
 	InteractiveType struct {
+		Type        string       `json:"type,omitempty"`
 		ButtonReply *ButtonReply `json:"button_reply,omitempty"`
 		ListReply   *ListReply   `json:"list_reply,omitempty"`
 	}

--- a/webhooks/models.go
+++ b/webhooks/models.go
@@ -118,7 +118,7 @@ type (
 		ID           string           `json:"id,omitempty"`
 		RecipientID  string           `json:"recipient_id,omitempty"`
 		StatusValue  string           `json:"status,omitempty"`
-		Timestamp    int              `json:"timestamp,omitempty"`
+		Timestamp    string           `json:"timestamp,omitempty"`
 		Conversation *Conversation    `json:"conversation,omitempty"`
 		Pricing      *Pricing         `json:"pricing,omitempty"`
 		Errors       []*werrors.Error `json:"werrors,omitempty"`


### PR DESCRIPTION
## Description
I found out after testing that the type of timestamp is string

## Motivation
fix bugs

## Solution
Changed the type of timestamp to string

## Additional Context
Add any other context about the pull request here.


```json

{
	"object": "whatsapp_business_account",
	"entry": [
		{
			"id": "122409997612427",
			"changes": [
				{
					"value": {
						"messaging_product": "whatsapp",
						"metadata": {
							"display_phone_number": "xxxx",
							"phone_number_id": "xxxx"
						},
						"statuses": [
							{
								"id": "wamid.HBgMMjAxMDE1NTA3NjI1FQIAERgSODNDMEZEQkJFODk3OTYwQTkxAA==",
								"status": "read",
								"timestamp": "1693487112",
								"recipient_id": "xxxxx"
							}
						]
					},
					"field": "messages"
				}
			]
		}
	]
}

```
