### PR TITLE
Add a 'parameter_name' field to TemplateParameter

### DIFF
--- a/message/templates.go
+++ b/message/templates.go
@@ -73,6 +73,7 @@ type (
 	TemplateParameter struct {
 		Type             string            `json:"type"`
 		Text             string            `json:"text"`
+		Name             string            `json:"parameter_name,omitempty"`
 		Payload          string            `json:"payload,omitempty"`
 		Currency         *TemplateCurrency `json:"currency"`
 		DateTime         *TemplateDateTime `json:"date_time"`


### PR DESCRIPTION
When working with multiple parameter templates, it is necessary to set the 'parameter_name' field in the parameters list, or else the parameters are not correctly interpreted into the template.

This PR makes a minimal change, adding the necessary field as an optional (aka "omitempty") member of the TemplateParameter type.