### PR TITLE
feat(pkg/http): snapshot request body before request interceptor

### DIFF
--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -131,19 +131,23 @@ func (core *CoreClient[T]) send(ctx context.Context, request *Request[T], decode
 	return nil
 }
 
+// SendFuncWithInterceptors returns a SenderFunc that applies request and response
+// interceptors around the actual HTTP call.
+//
+// Both request and response bodies are snapshotted before the interceptor runs and
+// restored afterwards, so interceptors can read the body freely without affecting the
+// HTTP call or downstream decoding.
 func SendFuncWithInterceptors[T any](client *http.Client, reqHook RequestInterceptorFunc,
 	resHook ResponseInterceptorFunc,
 ) SenderFunc[T] {
-	fn := SenderFunc[T](func(ctx context.Context, request *Request[T], decoder ResponseDecoder) error {
+	return SenderFunc[T](func(ctx context.Context, request *Request[T], decoder ResponseDecoder) error {
 		req, err := RequestWithContext(ctx, request)
 		if err != nil {
 			return err
 		}
 
-		if reqHook != nil {
-			if errHook := reqHook(ctx, req); errHook != nil {
-				return errHook
-			}
+		if err = applyRequestInterceptor(ctx, req, reqHook); err != nil {
+			return err
 		}
 
 		response, err := client.Do(req) //nolint:bodyclose // body closed
@@ -155,16 +159,8 @@ func SendFuncWithInterceptors[T any](client *http.Client, reqHook RequestInterce
 			_ = Body.Close()
 		}(response.Body)
 
-		if resHook != nil {
-			bodyBytes, errRead := io.ReadAll(response.Body)
-			if errRead != nil && !errors.Is(errRead, io.EOF) {
-				return fmt.Errorf("read response body: %w", errRead)
-			}
-			response.Body = io.NopCloser(bytes.NewReader(bodyBytes))
-			if errHook := resHook.InterceptResponse(ctx, response); errHook != nil {
-				return errHook
-			}
-			response.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+		if err = applyResponseInterceptor(ctx, response, resHook); err != nil {
+			return err
 		}
 
 		if err = decoder.Decode(ctx, response); err != nil {
@@ -173,8 +169,53 @@ func SendFuncWithInterceptors[T any](client *http.Client, reqHook RequestInterce
 
 		return nil
 	})
+}
 
-	return fn
+func applyRequestInterceptor(ctx context.Context, req *http.Request, hook RequestInterceptorFunc) error {
+	if hook == nil {
+		return nil
+	}
+
+	var reqBodyBytes []byte
+	if req.Body != nil {
+		var err error
+		reqBodyBytes, err = io.ReadAll(req.Body)
+		if err != nil {
+			return fmt.Errorf("read request body for interceptor: %w", err)
+		}
+		req.Body = io.NopCloser(bytes.NewReader(reqBodyBytes))
+	}
+
+	if err := hook(ctx, req); err != nil {
+		return err
+	}
+
+	if req.Body != nil {
+		req.Body = io.NopCloser(bytes.NewReader(reqBodyBytes))
+	}
+
+	return nil
+}
+
+func applyResponseInterceptor(ctx context.Context, resp *http.Response, hook ResponseInterceptorFunc) error {
+	if hook == nil {
+		return nil
+	}
+
+	bodyBytes, errRead := io.ReadAll(resp.Body)
+	if errRead != nil && !errors.Is(errRead, io.EOF) {
+		return fmt.Errorf("read response body: %w", errRead)
+	}
+
+	resp.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+
+	if err := hook.InterceptResponse(ctx, resp); err != nil {
+		return err
+	}
+
+	resp.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+
+	return nil
 }
 
 func (core *CoreClient[T]) Send(ctx context.Context, request *Request[T], decoder ResponseDecoder) error {

--- a/pkg/http/http_test.go
+++ b/pkg/http/http_test.go
@@ -806,7 +806,6 @@ func TestCoreClient_InterceptorsWithBody(t *testing.T) {
 		if req.Body != nil {
 			body, _ := io.ReadAll(req.Body)
 			interceptedReqBody = string(body)
-			req.Body = io.NopCloser(bytes.NewReader(body))
 		}
 		return nil
 	})
@@ -814,7 +813,6 @@ func TestCoreClient_InterceptorsWithBody(t *testing.T) {
 	resHook := whttp.ResponseInterceptorFunc(func(ctx context.Context, resp *http.Response) error {
 		body, _ := io.ReadAll(resp.Body)
 		interceptedResBody = string(body)
-		resp.Body = io.NopCloser(bytes.NewReader(body))
 		return nil
 	})
 
@@ -846,6 +844,156 @@ func TestCoreClient_InterceptorsWithBody(t *testing.T) {
 	if result.Name != "response" || result.Value != 999 {
 		t.Errorf("expected Name=response and Value=999, got Name=%s and Value=%d", result.Name, result.Value)
 	}
+}
+
+func TestRequestInterceptor_ConsumesBodyWithoutRestoring(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		if len(body) == 0 {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(`{"name":"empty-body","value":0}`))
+
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"name":"ok","value":1}`))
+	}))
+	defer server.Close()
+
+	reqHook := whttp.RequestInterceptorFunc(func(ctx context.Context, req *http.Request) error {
+		// Consume body but DO NOT restore it — the framework now handles restoration.
+		_, _ = io.ReadAll(req.Body)
+		return nil
+	})
+
+	sender := whttp.NewSender(
+		whttp.WithCoreClientRequestInterceptor[TestMessage](reqHook),
+	)
+
+	req := &whttp.Request[TestMessage]{
+		Method:  http.MethodPost,
+		BaseURL: server.URL,
+		Message: &TestMessage{Name: "request", Value: 42},
+	}
+
+	result := &TestMessage{}
+	decoder := whttp.ResponseDecoderJSON(result, whttp.DecodeOptions{})
+
+	err := sender.Send(context.Background(), req, decoder)
+	test.AssertNoError(t, "Send", err)
+
+	// The server received the full body because the framework restored it.
+	if result.Name != "ok" || result.Value != 1 {
+		t.Errorf("expected server to receive full body (ok response), got Name=%q Value=%d", result.Name, result.Value)
+	}
+}
+
+func TestResponseInterceptor_ConsumesBodyWithoutRestoring(t *testing.T) {
+	t.Parallel()
+
+	responseBody := `{"name":"response","value":999}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(responseBody))
+	}))
+	defer server.Close()
+
+	reqHook := whttp.RequestInterceptorFunc(func(ctx context.Context, req *http.Request) error {
+		// Restore request body so the server gets it.
+		if req.Body != nil {
+			body, _ := io.ReadAll(req.Body)
+			req.Body = io.NopCloser(bytes.NewReader(body))
+		}
+		return nil
+	})
+
+	resHook := whttp.ResponseInterceptorFunc(func(ctx context.Context, resp *http.Response) error {
+		// Consume body but DO NOT restore it — the framework should still protect
+		// downstream decoding.
+		_, _ = io.ReadAll(resp.Body)
+		return nil
+	})
+
+	sender := whttp.NewSender(
+		whttp.WithCoreClientRequestInterceptor[TestMessage](reqHook),
+		whttp.WithCoreClientResponseInterceptor[TestMessage](resHook),
+	)
+
+	req := &whttp.Request[TestMessage]{
+		Method:  http.MethodPost,
+		BaseURL: server.URL,
+		Message: &TestMessage{Name: "request", Value: 42},
+	}
+
+	result := &TestMessage{}
+	decoder := whttp.ResponseDecoderJSON(result, whttp.DecodeOptions{})
+
+	err := sender.Send(context.Background(), req, decoder)
+	test.AssertNoError(t, "Send", err)
+
+	// Decoder still gets the full body because the framework restored it.
+	if result.Name != "response" || result.Value != 999 {
+		t.Errorf(
+			"expected decoder to receive full body despite interceptor not restoring, got Name=%s Value=%d",
+			result.Name,
+			result.Value,
+		)
+	}
+}
+
+func Example_interceptorBodyGotcha() {
+	// This example demonstrates safe body handling in interceptors.
+	//
+	// Both request and response interceptors are body-safe: the framework snapshots
+	// the body before the interceptor runs and restores it afterwards. You can read
+	// req.Body or resp.Body freely without breaking the downstream call or decoder.
+
+	echoHandler := func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(body)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(echoHandler))
+	defer server.Close()
+
+	// Read the request body freely — the framework restores it automatically.
+	reqInterceptor := func(_ context.Context, req *http.Request) error {
+		if req.Body == nil {
+			return nil
+		}
+		body, _ := io.ReadAll(req.Body)
+		fmt.Println("request body length:", len(body))
+		return nil
+	}
+
+	// Read the response body freely — the framework restores it automatically.
+	resInterceptor := func(_ context.Context, res *http.Response) error {
+		_, _ = io.ReadAll(res.Body)
+		fmt.Println("response status:", res.StatusCode)
+		return nil
+	}
+
+	sender := whttp.NewSender(
+		whttp.WithCoreClientRequestInterceptor[TestMessage](reqInterceptor),
+		whttp.WithCoreClientResponseInterceptor[TestMessage](resInterceptor),
+	)
+
+	req := &whttp.Request[TestMessage]{
+		Method:  http.MethodPost,
+		BaseURL: server.URL,
+		Message: &TestMessage{Name: "hello", Value: 1},
+	}
+
+	decoder := whttp.ResponseDecoderJSON(&TestMessage{}, whttp.DecodeOptions{})
+	_ = sender.Send(context.Background(), req, decoder)
+
+	// Output:
+	// request body length: 27
+	// response status: 200
 }
 
 func TestAnySenderFunc_Send(t *testing.T) {

--- a/pkg/http/interceptors.go
+++ b/pkg/http/interceptors.go
@@ -25,11 +25,21 @@ import (
 )
 
 type (
+	// RequestInterceptorFunc intercepts an outgoing HTTP request before it is sent.
+	//
+	// The framework snapshots the request body before calling the interceptor and
+	// restores the original body afterward, so reading req.Body does not affect the
+	// actual HTTP call.
 	RequestInterceptorFunc func(ctx context.Context, request *http.Request) error
 	RequestInterceptor     interface {
 		InterceptRequest(ctx context.Context, request *http.Request) error
 	}
 
+	// ResponseInterceptorFunc intercepts an HTTP response before it is decoded.
+	//
+	// The framework snapshots the response body before calling the interceptor and
+	// restores the original body afterward, so reading resp.Body does not affect
+	// downstream decoding.
 	ResponseInterceptorFunc func(ctx context.Context, response *http.Response) error
 	ResponseInterceptor     interface {
 		InterceptResponse(ctx context.Context, response *http.Response) error


### PR DESCRIPTION
Make request interceptors body-safe by mirroring the existing response interceptor behavior: snapshot the body before the interceptor runs and restore it afterwards.

This removes the gotcha where consuming req.Body in a request interceptor would send an empty body or fail with a ContentLength mismatch.

- add applyRequestInterceptor and applyResponseInterceptor helpers
- update godoc to reflect automatic body restoration
- add tests and example for the safe behavior