### PR TITLE
calls: add call transcription support

### DIFF
--- a/calls/calls.go
+++ b/calls/calls.go
@@ -133,6 +133,28 @@ type Recording struct {
 	AnnouncementLanguage string          `json:"announcement_language,omitempty"`
 }
 
+// TranscriptionStatus indicates whether call transcription is enabled or disabled.
+type TranscriptionStatus string
+
+const (
+	TranscriptionEnabled  TranscriptionStatus = "ENABLED"
+	TranscriptionDisabled TranscriptionStatus = "DISABLED"
+)
+
+// Transcription configures call transcription on a per-call basis. Add it to
+// [CallUpdateStatusRequest] when initiating or accepting a call. When Status
+// is ENABLED, Purpose and AnnouncementLanguage are required (Purpose max 250 chars).
+//
+// Transcription and [Recording] are independent features — enable either, both,
+// or neither. When both are enabled, participants hear a single combined
+// announcement and you receive both a call_recording_available and a
+// call_transcription_available webhook.
+type Transcription struct {
+	Status               TranscriptionStatus `json:"status"`
+	Purpose              string              `json:"purpose,omitempty"`
+	AnnouncementLanguage string              `json:"announcement_language,omitempty"`
+}
+
 type (
 	// Client orchestrates high-level Calls API operations. It holds a reference to
 	// a [BaseClient] for HTTP transport and a [config.Config] for endpoint and
@@ -152,12 +174,13 @@ type (
 	// CallUpdateStatusRequest carries the payload for transitioning a call's
 	// lifecycle state. The Action field determines which fields are required.
 	CallUpdateStatusRequest struct {
-		CallID                string       `json:"call_id"`
-		Action                CallAction   `json:"action"`
-		Session               *SessionInfo `json:"session,omitempty"`                  // Required for connect (offer) and accept (answer)
-		BizOpaqueCallbackData string       `json:"biz_opaque_callback_data,omitempty"` // Max 512 characters string for tracking
-		To                    string       `json:"to,omitempty"`                       // Recipient's WA ID. Required only for 'connect'
-		Recording             *Recording   `json:"recording,omitempty"`                // Optional call recording configuration
+		CallID                string         `json:"call_id"`
+		Action                CallAction     `json:"action"`
+		Session               *SessionInfo   `json:"session,omitempty"`                  // Required for connect (offer) and accept (answer)
+		BizOpaqueCallbackData string         `json:"biz_opaque_callback_data,omitempty"` // Max 512 characters string for tracking
+		To                    string         `json:"to,omitempty"`                       // Recipient's WA ID. Required only for 'connect'
+		Recording             *Recording     `json:"recording,omitempty"`                // Optional call recording configuration
+		Transcription         *Transcription `json:"transcription,omitempty"`            // Optional call transcription configuration
 	}
 
 	// CallPermissionCheckResponse is the decoded response from a permission check.
@@ -201,6 +224,7 @@ type (
 		UserWaID              string            `json:"-"`
 		To                    string            `json:"to,omitempty"`
 		Recording             *Recording        `json:"-"`
+		Transcription         *Transcription    `json:"-"`
 	}
 
 	// BaseResponse acts as a flexible intermediate data capture layer unmarshaling
@@ -216,13 +240,14 @@ type (
 
 	// BaseRequest is the wire-format payload sent for call status updates.
 	BaseRequest struct {
-		MessagingProduct      string       `json:"messaging_product,omitempty"`
-		To                    string       `json:"to,omitempty"`
-		CallID                string       `json:"call_id,omitempty"`
-		Action                CallAction   `json:"action,omitempty"`
-		Session               *SessionInfo `json:"session,omitempty"`
-		BizOpaqueCallbackData string       `json:"biz_opaque_callback_data,omitempty"`
-		Recording             *Recording   `json:"recording,omitempty"`
+		MessagingProduct      string         `json:"messaging_product,omitempty"`
+		To                    string         `json:"to,omitempty"`
+		CallID                string         `json:"call_id,omitempty"`
+		Action                CallAction     `json:"action,omitempty"`
+		Session               *SessionInfo   `json:"session,omitempty"`
+		BizOpaqueCallbackData string         `json:"biz_opaque_callback_data,omitempty"`
+		Recording             *Recording     `json:"recording,omitempty"`
+		Transcription         *Transcription `json:"transcription,omitempty"`
 	}
 
 	// CallUpdateStatusResponse is the API response for a successful status update.
@@ -302,6 +327,7 @@ func (c *Client) UpdateCallStatus(
 		RequestType:           whttp.RequestTypeUpdateCallStatus,
 		To:                    request.To,
 		Recording:             request.Recording,
+		Transcription:         request.Transcription,
 	}
 
 	resp, err := c.Send(ctx, req)
@@ -416,6 +442,7 @@ func (bc *BaseClient) Send(ctx context.Context, conf *config.Config, request *Re
 			Session:               request.Session,
 			BizOpaqueCallbackData: request.BizOpaqueCallbackData,
 			Recording:             request.Recording,
+			Transcription:         request.Transcription,
 		}
 		endpoint = callStatusUpdateEndpoint
 		method = http.MethodPost
@@ -503,6 +530,14 @@ func (s *CallUpdateStatusRequest) SetBizOpaqueCallbackData(bizOpaqueCallbackData
 // WhatsApp API (purpose max 250 characters).
 func (s *CallUpdateStatusRequest) SetRecording(r *Recording) {
 	s.Recording = r
+}
+
+// SetTranscription configures call transcription on this request. Use
+// [TranscriptionEnabled] to enable or [TranscriptionDisabled] to explicitly
+// opt out. When enabling, purpose and announcementLanguage are required per
+// the WhatsApp API (purpose max 250 characters).
+func (s *CallUpdateStatusRequest) SetTranscription(t *Transcription) {
+	s.Transcription = t
 }
 
 // NewCheckPermissionRequest creates a permission check request for the given

--- a/calls/calls_test.go
+++ b/calls/calls_test.go
@@ -1892,6 +1892,202 @@ func TestCallRecording_JSONRoundTrip(t *testing.T) {
 	test.AssertJSONRoundTrip(t, "CallRecording", rec)
 }
 
+func TestTranscription_JSONRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	t.Run("enabled", func(t *testing.T) {
+		t.Parallel()
+		tr := &calls.Transcription{
+			Status:               calls.TranscriptionEnabled,
+			Purpose:              "quality assurance",
+			AnnouncementLanguage: "en_US",
+		}
+		test.AssertJSONRoundTrip(t, "Transcription enabled", tr)
+	})
+
+	t.Run("disabled", func(t *testing.T) {
+		t.Parallel()
+		tr := &calls.Transcription{Status: calls.TranscriptionDisabled}
+		test.AssertJSONRoundTrip(t, "Transcription disabled", tr)
+	})
+}
+
+func TestTranscription_MarshalMatchesExpected(t *testing.T) {
+	t.Parallel()
+
+	tr := &calls.Transcription{
+		Status:               calls.TranscriptionEnabled,
+		Purpose:              "quality assurance",
+		AnnouncementLanguage: "en_US",
+	}
+	want := `{
+		"status": "ENABLED",
+		"purpose": "quality assurance",
+		"announcement_language": "en_US"
+	}`
+	test.AssertJSONMarshal(t, "Transcription", tr, want)
+}
+
+func TestConnectRequest_WithTranscription(t *testing.T) {
+	t.Parallel()
+
+	req := calls.ConnectRequest("16505551234", "sdp-offer")
+	req.SetTranscription(&calls.Transcription{
+		Status:               calls.TranscriptionEnabled,
+		Purpose:              "quality assurance",
+		AnnouncementLanguage: "en_US",
+	})
+
+	if req.Transcription == nil {
+		t.Fatal("expected non-nil Transcription")
+	}
+	if req.Transcription.Status != calls.TranscriptionEnabled {
+		t.Errorf("expected ENABLED, got %s", req.Transcription.Status)
+	}
+}
+
+func TestTranscription_ConnectViaMockServer(t *testing.T) {
+	t.Parallel()
+
+	payload, _ := json.Marshal(map[string]any{
+		"messaging_product": "whatsapp",
+		"success":           true,
+		"calls":             []map[string]string{{"id": "call-trans-1"}},
+	})
+	srv := test.NewMockServer(test.MockBehavior{
+		StatusCode: http.StatusOK,
+		Payload:    payload,
+	})
+	defer srv.Close()
+
+	client := calls.NewClient(mockConfig(srv.Server.URL))
+	req := calls.ConnectRequest("16505551234", "sdp-offer")
+	req.SetTranscription(&calls.Transcription{
+		Status:               calls.TranscriptionEnabled,
+		Purpose:              "quality assurance",
+		AnnouncementLanguage: "en_US",
+	})
+	_, err := client.UpdateCallStatus(context.Background(), req)
+	test.AssertNoError(t, "UpdateCallStatus with transcription failed", err)
+
+	reqs := srv.GetRequests()
+	r := reqs[0]
+
+	var body map[string]any
+	json.Unmarshal(r.Body, &body)
+
+	tr, ok := body["transcription"].(map[string]any)
+	if !ok {
+		t.Fatal("expected transcription in request body")
+	}
+	if tr["status"] != "ENABLED" {
+		t.Errorf("expected status=ENABLED, got %v", tr["status"])
+	}
+}
+
+func TestTranscriptionStatus_Values(t *testing.T) {
+	t.Parallel()
+
+	if calls.TranscriptionEnabled != "ENABLED" {
+		t.Errorf("expected ENABLED, got %s", calls.TranscriptionEnabled)
+	}
+	if calls.TranscriptionDisabled != "DISABLED" {
+		t.Errorf("expected DISABLED, got %s", calls.TranscriptionDisabled)
+	}
+}
+
+func TestCallTranscriptionAvailable_WebhookParsing(t *testing.T) {
+	t.Parallel()
+
+	docJSON := `{
+		"object": "whatsapp_business_account",
+		"entry": [{
+			"id": "123456789",
+			"changes": [{
+				"field": "calls",
+				"value": {
+					"messaging_product": "whatsapp",
+					"metadata": {
+						"phone_number_id": "106540352242922",
+						"display_phone_number": "15551234567"
+					},
+					"calls": [{
+						"id": "wacid.HBgLMTQxMjYxMzYyNTMVAgASGCBGO",
+						"from": "16505551234",
+						"timestamp": "1728932177",
+						"event": "call_transcription_available",
+						"call_transcript": {
+							"document": {
+								"id": "1002764438271669",
+								"sha256": "Y9vvGyeo3n76ptkXu3CwDBsnzbRFqpjHskQdMGSVqas=",
+								"mime_type": "application/json",
+								"url": "https://lookaside.fbsbx.com/whatsapp_business/attachments/?mid=133"
+							}
+						}
+					}]
+				}
+			}]
+		}]
+	}`
+
+	var n webhooks.Notification
+	test.AssertJSONUnmarshal(t, "Transcription webhook", docJSON, &n)
+
+	call := n.Entry[0].Changes[0].Value.Calls[0]
+	if call.Event != "call_transcription_available" {
+		t.Errorf("expected call_transcription_available, got %s", call.Event)
+	}
+	if call.CallTranscript == nil {
+		t.Fatal("expected non-nil CallTranscript")
+	}
+	if call.CallTranscript.Document == nil {
+		t.Fatal("expected non-nil Document")
+	}
+	if call.CallTranscript.Document.ID != "1002764438271669" {
+		t.Errorf("unexpected document ID: %s", call.CallTranscript.Document.ID)
+	}
+	if call.CallTranscript.Document.MimeType != "application/json" {
+		t.Errorf("expected application/json, got %s", call.CallTranscript.Document.MimeType)
+	}
+
+	t.Run("handler dispatch", func(t *testing.T) {
+		t.Parallel()
+
+		handler := webhooks.NewHandler()
+		received := false
+		handler.OnCallTranscriptionAvailable(webhooks.CallsEventHandlerFunc[webhooks.Call](
+			func(_ context.Context, req *webhooks.CallRequest[webhooks.Call]) error {
+				received = true
+				if req.Payload.CallTranscript == nil {
+					t.Error("expected CallTranscript in payload")
+				}
+				return nil
+			},
+		))
+
+		events := n.Events()
+		err := handler.HandleNotificationEvent(context.Background(), events[0])
+		test.AssertNoError(t, "HandleNotificationEvent failed", err)
+		if !received {
+			t.Error("transcription handler was not called")
+		}
+	})
+}
+
+func TestCallTranscript_JSONRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	ct := &webhooks.CallTranscript{
+		Document: &media.Info{
+			ID:       "1002764438271669",
+			Sha256:   "Y9vvGyeo3n76ptkXu3CwDBsnzbRFqpjHskQdMGSVqas=",
+			MimeType: "application/json",
+			URL:      "https://lookaside.fbsbx.com/whatsapp_business/attachments/?mid=133",
+		},
+	}
+	test.AssertJSONRoundTrip(t, "CallTranscript", ct)
+}
+
 func TestCmpIntegration(t *testing.T) {
 	// Verify that the google/go-cmp dependency is wired correctly.
 	// This is not testing calls functionality directly, but confirms the

--- a/webhooks/calls.go
+++ b/webhooks/calls.go
@@ -90,6 +90,11 @@ type (
 	// (event: "call_recording_available"). Payload: [Call] — call_recording
 	// field carries the downloadable audio asset details.
 	CallRecordingAvailableHandler = CallsEventHandler[Call]
+
+	// CallTranscriptionAvailableHandler handles transcription-available events
+	// (event: "call_transcription_available"). Payload: [Call] — call_transcript
+	// field carries the downloadable transcript document details.
+	CallTranscriptionAvailableHandler = CallsEventHandler[Call]
 )
 
 // CallsHandler groups all per-event-type handlers for the calls webhook field
@@ -124,6 +129,9 @@ type CallsHandler struct {
 	// RecordingAvailable handles recording-available events
 	// (event: "call_recording_available"). Payload: [Call].
 	recordingAvailable CallsEventHandler[Call]
+	// TranscriptionAvailable handles transcription-available events
+	// (event: "call_transcription_available"). Payload: [Call].
+	transcriptionAvailable CallsEventHandler[Call]
 
 	// Fallback is called for any call event that does not have a dedicated
 	// handler set — both unknown event types and known types left nil.
@@ -166,6 +174,12 @@ func (ch *CallsHandler) OnCallStatus(h CallStatusHandler) {
 // (event: "call_recording_available"). Payload: [Call] with CallRecording populated.
 func (ch *CallsHandler) OnCallRecordingAvailable(h CallRecordingAvailableHandler) {
 	ch.recordingAvailable = h
+}
+
+// OnCallTranscriptionAvailable sets the handler for transcription-available events
+// (event: "call_transcription_available"). Payload: [Call] with CallTranscript populated.
+func (ch *CallsHandler) OnCallTranscriptionAvailable(h CallTranscriptionAvailableHandler) {
+	ch.transcriptionAvailable = h
 }
 
 // OnFallback sets the catch-all handler for call events without a dedicated
@@ -291,6 +305,17 @@ func (ch *CallsHandler) Handle(
 				}
 				continue
 			}
+		case "call_transcription_available":
+			if ch.transcriptionAvailable != nil {
+				req := &CallRequest[Call]{
+					Context: nctx,
+					Payload: call,
+				}
+				if err := ch.transcriptionAvailable.Handle(ctx, req); err != nil {
+					return ch.HandleError(ctx, fmt.Errorf("calls transcription: %w", err))
+				}
+				continue
+			}
 		}
 		// Unknown event type or nil handler → fallback for this call.
 		return ErrEventNotHandled
@@ -301,24 +326,25 @@ func (ch *CallsHandler) Handle(
 
 type (
 	Call struct {
-		ID                    string         `json:"id"` // The WhatsApp call ID
-		To                    string         `json:"to"` // The WhatsApp user's phone number (callee)
-		ToUserID              string         `json:"to_user_id,omitempty"`
-		ToParentUserID        string         `json:"to_parent_user_id,omitempty"`
-		From                  string         `json:"from"`
-		Event                 string         `json:"event"`
-		Timestamp             string         `json:"timestamp"`
-		Direction             string         `json:"direction"`
-		DeepLinkPayload       string         `json:"deeplink_payload,omitempty"`
-		CTAPayload            string         `json:"cta_payload,omitempty"`
-		Status                string         `json:"status"`
-		StartTime             string         `json:"start_time"`
-		EndTime               string         `json:"end_time"`
-		Duration              int            `json:"duration"`
-		BizOpaqueCallbackData string         `json:"biz_opaque_callback_data,omitempty"`
-		Session               *CallSession   `json:"session,omitempty"`
-		Connection            *Connection    `json:"connection,omitempty"`
-		CallRecording         *CallRecording `json:"call_recording,omitempty"`
+		ID                    string          `json:"id"` // The WhatsApp call ID
+		To                    string          `json:"to"` // The WhatsApp user's phone number (callee)
+		ToUserID              string          `json:"to_user_id,omitempty"`
+		ToParentUserID        string          `json:"to_parent_user_id,omitempty"`
+		From                  string          `json:"from"`
+		Event                 string          `json:"event"`
+		Timestamp             string          `json:"timestamp"`
+		Direction             string          `json:"direction"`
+		DeepLinkPayload       string          `json:"deeplink_payload,omitempty"`
+		CTAPayload            string          `json:"cta_payload,omitempty"`
+		Status                string          `json:"status"`
+		StartTime             string          `json:"start_time"`
+		EndTime               string          `json:"end_time"`
+		Duration              int             `json:"duration"`
+		BizOpaqueCallbackData string          `json:"biz_opaque_callback_data,omitempty"`
+		Session               *CallSession    `json:"session,omitempty"`
+		Connection            *Connection     `json:"connection,omitempty"`
+		CallRecording         *CallRecording  `json:"call_recording,omitempty"`
+		CallTranscript        *CallTranscript `json:"call_transcript,omitempty"`
 	}
 
 	CallSession struct {
@@ -333,6 +359,15 @@ type (
 	CallRecording struct {
 		Type  string      `json:"type"`
 		Audio *media.Info `json:"audio,omitempty"`
+	}
+
+	// CallTranscript wraps the transcription payload delivered in a
+	// call_transcription_available webhook event. Document uses [media.Info]
+	// — the same type used for incoming media messages. The downloaded
+	// document is a JSON file with metadata, transcript text, language
+	// detection, confidence scores, and word-level segments.
+	CallTranscript struct {
+		Document *media.Info `json:"document,omitempty"`
 	}
 
 	WebRTC struct {
@@ -370,6 +405,8 @@ func (ch *CallsHandler) CanHandleEvent(event NotificationEvent) bool {
 			return ch.terminate != nil
 		case "call_recording_available":
 			return ch.recordingAvailable != nil
+		case "call_transcription_available":
+			return ch.transcriptionAvailable != nil
 		}
 	}
 	return false
@@ -400,6 +437,14 @@ func (handler *Handler) OnCallStatus(h CallStatusHandler) {
 // OnCallRecordingAvailable registers a handler for call recording available events.
 func (handler *Handler) OnCallRecordingAvailable(h CallRecordingAvailableHandler) {
 	handler.calls.OnCallRecordingAvailable(h)
+}
+
+// OnCallTranscriptionAvailable registers a handler for call transcription
+// available events. The handler receives the full Call payload with
+// CallTranscript populated — use call_transcript.document.id with the Media
+// API to download the transcript JSON document.
+func (handler *Handler) OnCallTranscriptionAvailable(h CallTranscriptionAvailableHandler) {
+	handler.calls.OnCallTranscriptionAvailable(h)
 }
 
 // CallPermissionReply represents a WhatsApp user's response to a call


### PR DESCRIPTION
Add Transcription struct with Status (ENABLED/DISABLED), Purpose, and AnnouncementLanguage. Wire through the full chain following the same pattern as Recording (independent feature, same API endpoint).

calls/calls.go:
- TranscriptionStatus type + Enabled/Disabled constants
- Transcription struct with JSON tags for wire format
- Transcription field on CallUpdateStatusRequest, Request, BaseRequest
- SetTranscription helper on CallUpdateStatusRequest
- Client.UpdateCallStatus and BaseClient.Send both pass Transcription

webhooks/calls.go:
- CallTranscript type wrapping media.Info as Document
- CallTranscript field on Call struct
- TranscriptionAvailable handler on CallsHandler
- OnCallTranscriptionAvailable registration + type alias
- Dispatch case for call_transcription_available in Handle/CanHandleEvent
- OnCallTranscriptionAvailable convenience method on Handler

calls/calls_test.go:
- 10 tests: JSON round-trip, marshal, SetTranscription, MockServer HTTP integration, webhook payload parsing, handler dispatch