### PR TITLE
analytics: complete implementation

### DIFF
--- a/business/analytics/analytics.go
+++ b/business/analytics/analytics.go
@@ -60,6 +60,11 @@ func (c *Client) SetMiddlewares(mws ...whttp.Middleware[BaseRequest]) {
 	c.sender.SetMiddlewares(mws...)
 }
 
+// CloseIdleConnections closes any idle connections in the underlying HTTP client.
+func (c *Client) CloseIdleConnections() {
+	c.sender.CloseIdleConnections()
+}
+
 // Send dispatches a raw [Request] through the underlying [BaseClient].
 func (c *Client) Send(ctx context.Context, request *Request) (*BaseResponse, error) {
 	response, err := c.sender.Send(ctx, c.config, request)
@@ -108,6 +113,23 @@ func (c *Client) FetchPricingAnalytics(ctx context.Context, params *PricingReque
 	return resp.PricingAnalytics(), nil
 }
 
+// FetchCallAnalytics retrieves call analytics for the specified date range and filters.
+// Call analytics provides the number and type of calls made and received by phone numbers
+// associated with the WhatsApp Business Account.
+func (c *Client) FetchCallAnalytics(ctx context.Context, params *CallAnalyticsRequest) (
+	*CallAnalyticsResponse, error,
+) {
+	req := MakeCallAnalyticsQueryParams(params.Start, params.End,
+		params.Granularity, params.Options...)
+
+	resp, err := c.Send(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("fetch call analytics: %w", err)
+	}
+
+	return resp.CallAnalytics(), nil
+}
+
 func (bc *BaseClient) FetchGeneralAnalytics(ctx context.Context, conf *config.Config,
 	request *MessagingRequest,
 ) (*MessagingResponse, error) {
@@ -147,6 +169,20 @@ func (bc *BaseClient) FetchPricingAnalytics(ctx context.Context, conf *config.Co
 	return resp.PricingAnalytics(), nil
 }
 
+// FetchCallAnalytics retrieves call analytics for the specified date range and filters.
+// This is the multi-tenant variant that accepts a per-call config.
+func (bc *BaseClient) FetchCallAnalytics(ctx context.Context, conf *config.Config,
+	params *CallAnalyticsRequest,
+) (*CallAnalyticsResponse, error) {
+	request := MakeCallAnalyticsQueryParams(params.Start, params.End, params.Granularity, params.Options...)
+	resp, err := bc.FetchAnalytics(ctx, conf, request)
+	if err != nil {
+		return nil, fmt.Errorf("fetch call analytics: %w", err)
+	}
+
+	return resp.CallAnalytics(), nil
+}
+
 func (bc *BaseClient) FetchAnalytics(
 	ctx context.Context,
 	conf *config.Config,
@@ -180,10 +216,12 @@ func (bc *BaseClient) Send(ctx context.Context, conf *config.Config, request *Re
 }
 
 // BaseResponse is the general response struct for the Analytics API.
+// Each analytics type is decoded into its own field based on the requested fields parameter.
 type BaseResponse struct {
 	Messaging      *MessagingAnalytics    `json:"analytics,omitempty"`
 	Conversational *ConversationAnalytics `json:"conversation_analytics,omitempty"`
 	Pricing        *PricingAnalytics      `json:"pricing_analytics,omitempty"`
+	Call           *CallAnalytics         `json:"call_analytics,omitempty"`
 	ID             string                 `json:"id,omitempty"`
 }
 
@@ -205,6 +243,14 @@ func (response *BaseResponse) PricingAnalytics() *PricingResponse {
 	return &PricingResponse{
 		PricingAnalytics: response.Pricing,
 		ID:               response.ID,
+	}
+}
+
+// CallAnalytics returns the call analytics portion of the response.
+func (response *BaseResponse) CallAnalytics() *CallAnalyticsResponse {
+	return &CallAnalyticsResponse{
+		CallAnalytics: response.Call,
+		ID:            response.ID,
 	}
 }
 
@@ -454,6 +500,110 @@ func MakePricingAnalyticsQueryParams(start, end int64, granularity Granularity,
 	}
 }
 
+// Call analytics types.
+
+type (
+	// CallAnalyticsRequest is the user-facing request for call analytics.
+	CallAnalyticsRequest struct {
+		Start       int64
+		End         int64
+		Granularity Granularity
+		Options     []CallAnalyticsQueryParamsOption
+	}
+
+	// CallAnalyticsResponse contains the call analytics data returned by the API.
+	CallAnalyticsResponse struct {
+		CallAnalytics *CallAnalytics `json:"call_analytics,omitempty"`
+		ID            string         `json:"id,omitempty"`
+	}
+
+	// CallAnalytics holds call analytics data including granularity, directions, and data points.
+	CallAnalytics struct {
+		Granularity string                    `json:"granularity,omitempty"`
+		Directions  string                    `json:"directions,omitempty"`
+		DataPoints  []*CallAnalyticsDataPoint `json:"data_points,omitempty"`
+	}
+
+	// CallAnalyticsDataPoint represents a single data point in call analytics.
+	CallAnalyticsDataPoint struct {
+		Start           int64   `json:"start,omitempty"`
+		End             int64   `json:"end,omitempty"`
+		Cost            float64 `json:"cost,omitempty"`
+		Count           int64   `json:"count,omitempty"`
+		AverageDuration int64   `json:"average_duration,omitempty"`
+	}
+
+	CallAnalyticsQueryParams struct {
+		PhoneNumbers []string
+		CountryCodes []string
+		Directions   []CallDirection
+		Dimensions   []Dimension
+		MetricTypes  []MetricType
+	}
+
+	CallAnalyticsQueryParamsOption func(*CallAnalyticsQueryParams)
+)
+
+// WithCallPhoneNumbers filters call analytics by phone numbers.
+func WithCallPhoneNumbers(phoneNumbers ...string) CallAnalyticsQueryParamsOption {
+	return func(p *CallAnalyticsQueryParams) {
+		p.PhoneNumbers = phoneNumbers
+	}
+}
+
+// WithCallCountryCodes filters call analytics by country codes.
+func WithCallCountryCodes(countryCodes ...string) CallAnalyticsQueryParamsOption {
+	return func(p *CallAnalyticsQueryParams) {
+		p.CountryCodes = countryCodes
+	}
+}
+
+// WithCallDirections filters call analytics by call direction.
+func WithCallDirections(directions ...CallDirection) CallAnalyticsQueryParamsOption {
+	return func(p *CallAnalyticsQueryParams) {
+		p.Directions = directions
+	}
+}
+
+// WithCallDimensions applies dimension breakdowns to call analytics.
+func WithCallDimensions(dimensions ...Dimension) CallAnalyticsQueryParamsOption {
+	return func(p *CallAnalyticsQueryParams) {
+		p.Dimensions = dimensions
+	}
+}
+
+// WithCallMetricTypes filters the metric types returned in call analytics.
+func WithCallMetricTypes(metricTypes ...MetricType) CallAnalyticsQueryParamsOption {
+	return func(p *CallAnalyticsQueryParams) {
+		p.MetricTypes = metricTypes
+	}
+}
+
+// MakeCallAnalyticsQueryParams builds a [Request] for call analytics with the given
+// date range, granularity, and optional filters.
+func MakeCallAnalyticsQueryParams(start, end int64, granularity Granularity,
+	options ...CallAnalyticsQueryParamsOption,
+) *Request {
+	params := &CallAnalyticsQueryParams{}
+
+	for _, option := range options {
+		option(params)
+	}
+
+	return &Request{
+		requestType:    whttp.RequestTypeFetchCallAnalytics,
+		Fields:         TypeCallAnalytics,
+		Start:          start,
+		End:            end,
+		Granularity:    granularity,
+		PhoneNumbers:   params.PhoneNumbers,
+		CountryCodes:   params.CountryCodes,
+		CallDirections: params.Directions,
+		Dimensions:     params.Dimensions,
+		MetricTypes:    params.MetricTypes,
+	}
+}
+
 // BaseRequest is the wire-format payload for the Analytics API.
 // All analytics requests are GET-only, so the body is always empty.
 type BaseRequest struct{}
@@ -474,6 +624,7 @@ type Request struct {
 	Dimensions             []Dimension
 	PricingCategories      []PricingCategory
 	PricingTypes           []PricingType
+	CallDirections         []CallDirection
 }
 
 func (r *Request) QueryParamsString() string {
@@ -502,60 +653,87 @@ func (r *Request) QueryParamsString() string {
 
 	switch r.Fields { //nolint:exhaustive // ok
 	case TypeMessagingAnalytics:
-		if len(r.ProductTypes) > 0 {
-			appendParamValue(&buffer, "product_types", r.ProductTypes, func(productTypes []int64) string {
-				return formatArray(productTypes, formatInt)
-			})
-		}
+		r.appendMessagingFields(&buffer)
 	case TypeConversationAnalytics:
-		if len(r.MetricTypes) > 0 {
-			appendParamValue(&buffer, "metric_types", r.MetricTypes,
-				func(metricTypes []MetricType) string {
-					return formatArray(metricTypes, quoteString)
-				})
-		}
-		if len(r.ConversationCategories) > 0 {
-			appendParamValue(&buffer, "conversation_categories", r.ConversationCategories,
-				func(conversationCategories []ConversationalCategory) string {
-					return formatArray(conversationCategories, quoteString)
-				})
-		}
-		if len(r.ConversationTypes) > 0 {
-			appendParamValue(&buffer, "conversation_types", r.ConversationTypes,
-				func(conversationTypes []ConversationalType) string {
-					return formatArray(conversationTypes, quoteString)
-				})
-		}
-		if len(r.ConversationDirections) > 0 {
-			appendParamValue(&buffer, "conversation_directions", r.ConversationDirections,
-				func(conversationDirections []ConversationalDirection) string {
-					return formatArray(conversationDirections, quoteString)
-				})
-		}
-
+		r.appendConversationFields(&buffer)
 	case TypePricingAnalytics:
-		if len(r.MetricTypes) > 0 {
-			appendParamValue(&buffer, "metric_types", r.MetricTypes,
-				func(metricTypes []MetricType) string {
-					return formatArray(metricTypes, quoteString)
-				})
-		}
-		if len(r.PricingTypes) > 0 {
-			appendParamValue(&buffer, "pricing_types", r.PricingTypes,
-				func(pricingTypes []PricingType) string {
-					return formatArray(pricingTypes, quoteString)
-				})
-		}
-
-		if len(r.PricingCategories) > 0 {
-			appendParamValue(&buffer, "pricing_categories", r.PricingCategories,
-				func(pricingCategories []PricingCategory) string {
-					return formatArray(pricingCategories, quoteString)
-				})
-		}
+		r.appendPricingFields(&buffer)
+	case TypeCallAnalytics:
+		r.appendCallFields(&buffer)
 	}
 
 	return buffer.String()
+}
+
+func (r *Request) appendMessagingFields(buffer *strings.Builder) {
+	if len(r.ProductTypes) > 0 {
+		appendParamValue(buffer, "product_types", r.ProductTypes, func(productTypes []int64) string {
+			return formatArray(productTypes, formatInt)
+		})
+	}
+}
+
+func (r *Request) appendConversationFields(buffer *strings.Builder) {
+	if len(r.MetricTypes) > 0 {
+		appendParamValue(buffer, "metric_types", r.MetricTypes,
+			func(metricTypes []MetricType) string {
+				return formatArray(metricTypes, quoteString)
+			})
+	}
+	if len(r.ConversationCategories) > 0 {
+		appendParamValue(buffer, "conversation_categories", r.ConversationCategories,
+			func(conversationCategories []ConversationalCategory) string {
+				return formatArray(conversationCategories, quoteString)
+			})
+	}
+	if len(r.ConversationTypes) > 0 {
+		appendParamValue(buffer, "conversation_types", r.ConversationTypes,
+			func(conversationTypes []ConversationalType) string {
+				return formatArray(conversationTypes, quoteString)
+			})
+	}
+	if len(r.ConversationDirections) > 0 {
+		appendParamValue(buffer, "conversation_directions", r.ConversationDirections,
+			func(conversationDirections []ConversationalDirection) string {
+				return formatArray(conversationDirections, quoteString)
+			})
+	}
+}
+
+func (r *Request) appendPricingFields(buffer *strings.Builder) {
+	if len(r.MetricTypes) > 0 {
+		appendParamValue(buffer, "metric_types", r.MetricTypes,
+			func(metricTypes []MetricType) string {
+				return formatArray(metricTypes, quoteString)
+			})
+	}
+	if len(r.PricingTypes) > 0 {
+		appendParamValue(buffer, "pricing_types", r.PricingTypes,
+			func(pricingTypes []PricingType) string {
+				return formatArray(pricingTypes, quoteString)
+			})
+	}
+	if len(r.PricingCategories) > 0 {
+		appendParamValue(buffer, "pricing_categories", r.PricingCategories,
+			func(pricingCategories []PricingCategory) string {
+				return formatArray(pricingCategories, quoteString)
+			})
+	}
+}
+
+func (r *Request) appendCallFields(buffer *strings.Builder) {
+	if len(r.CallDirections) > 0 {
+		appendParamValue(buffer, "directions", r.CallDirections,
+			func(directions []CallDirection) string {
+				return formatArray(directions, quoteString)
+			})
+	}
+	if len(r.MetricTypes) > 0 {
+		appendParamValue(buffer, "metric_types", r.MetricTypes,
+			func(metricTypes []MetricType) string {
+				return formatArray(metricTypes, quoteString)
+			})
+	}
 }
 
 func formatArray[T any](arr []T, formatter func(T) string) string {
@@ -614,6 +792,7 @@ type (
 		Volume                int64   `json:"volume,omitempty"`
 		PricingType           string  `json:"pricing_type,omitempty"`
 		PricingCategory       string  `json:"pricing_category,omitempty"`
+		Tier                  string  `json:"tier,omitempty"`
 	}
 )
 
@@ -639,6 +818,7 @@ const (
 	TypeConversationAnalytics Type = "conversation_analytics"
 	TypeTemplateAnalytics     Type = "template_analytics"
 	TypePricingAnalytics      Type = "pricing_analytics"
+	TypeCallAnalytics         Type = "call_analytics"
 )
 
 type PricingCategory string
@@ -649,6 +829,8 @@ const (
 	PricingCategoryService                     PricingCategory = "SERVICE"
 	PricingCategoryUtility                     PricingCategory = "UTILITY"
 	PricingCategoryAuthenticationInternational PricingCategory = "AUTHENTICATION_INTERNATIONAL"
+	PricingCategoryMarketingLite               PricingCategory = "MARKETING_LITE"
+	PricingCategoryReferralConversion          PricingCategory = "REFERRAL_CONVERSION"
 )
 
 type PricingType string
@@ -671,9 +853,9 @@ const (
 type ConversationalType string
 
 const (
-	ConversationalTypeFreeEntry ConversationalType = "FREE_ENTRY"
-	ConversationalTypeFreeTier  ConversationalType = "FREE_TIER"
-	ConversationalTypeRegular   ConversationalType = "REGULAR"
+	ConversationalTypeFreeEntryPoint ConversationalType = "FREE_ENTRY_POINT"
+	ConversationalTypeFreeTier       ConversationalType = "FREE_TIER"
+	ConversationalTypeRegular        ConversationalType = "REGULAR"
 )
 
 type ConversationalDirection string
@@ -681,6 +863,15 @@ type ConversationalDirection string
 const (
 	ConversationalDirectionBusinessInitiated ConversationalDirection = "BUSINESS_INITIATED"
 	ConversationalDirectionUserInitiated     ConversationalDirection = "USER_INITIATED"
+	ConversationalDirectionUnknown           ConversationalDirection = "UNKNOWN"
+)
+
+// CallDirection represents the direction of a call for call analytics filtering.
+type CallDirection string
+
+const (
+	CallDirectionBusinessInitiated CallDirection = "BUSINESS_INITIATED"
+	CallDirectionUserInitiated     CallDirection = "USER_INITIATED"
 )
 
 type Dimension string
@@ -691,17 +882,24 @@ const (
 	DimensionConversationType      Dimension = "CONVERSATION_TYPE"
 	DimensionCountry               Dimension = "COUNTRY"
 	DimensionPhone                 Dimension = "PHONE"
+	DimensionPricingCategory       Dimension = "PRICING_CATEGORY"
+	DimensionPricingType           Dimension = "PRICING_TYPE"
+	DimensionTier                  Dimension = "TIER"
+	DimensionDirection             Dimension = "DIRECTION"
 )
 
 type MetricType string
 
 const (
-	MetricTypeCost         MetricType = "COST"
-	MetricTypeConversation MetricType = "CONVERSATION"
-	MetricTypeDelivered    MetricType = "DELIVERED"
-	MetricTypeRead         MetricType = "READ"
-	MetricTypeSent         MetricType = "SENT"
-	MetricTypeClicked      MetricType = "CLICKED"
+	MetricTypeCost            MetricType = "COST"
+	MetricTypeConversation    MetricType = "CONVERSATION"
+	MetricTypeDelivered       MetricType = "DELIVERED"
+	MetricTypeRead            MetricType = "READ"
+	MetricTypeSent            MetricType = "SENT"
+	MetricTypeClicked         MetricType = "CLICKED"
+	MetricTypeVolume          MetricType = "VOLUME"
+	MetricTypeCount           MetricType = "COUNT"
+	MetricTypeAverageDuration MetricType = "AVERAGE_DURATION"
 )
 
 type ProductType int64

--- a/business/analytics/analytics_integration_test.go
+++ b/business/analytics/analytics_integration_test.go
@@ -1,0 +1,422 @@
+//  Copyright 2023 Pius Alfred <me.pius1102@gmail.com>
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+//  and associated documentation files (the "Software"), to deal in the Software without restriction,
+//  including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+//  and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+//  subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all copies or substantial
+//  portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+//  LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+//  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+//  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+package analytics_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/piusalfred/whatsapp/business/analytics"
+	"github.com/piusalfred/whatsapp/config"
+	"github.com/piusalfred/whatsapp/internal/test"
+)
+
+func mockConfig(baseURL string) *config.Config {
+	return &config.Config{
+		BaseURL:           baseURL,
+		APIVersion:        "v25.0",
+		BusinessAccountID: "102290129340398",
+		AccessToken:       "EAAJB...",
+	}
+}
+
+func TestFetchGeneralAnalytics_MockServer(t *testing.T) {
+	t.Parallel()
+
+	payload, _ := json.Marshal(map[string]any{
+		"analytics": map[string]any{
+			"phone_numbers": []string{"16505550111"},
+			"country_codes": []string{"US"},
+			"granularity":   "DAY",
+			"data_points": []map[string]any{
+				{
+					"start":     1543543200,
+					"end":       1543629600,
+					"sent":      196093,
+					"delivered": 179715,
+				},
+			},
+		},
+		"id": "102290129340398",
+	})
+
+	srv := test.NewMockServer(test.MockBehavior{
+		StatusCode: http.StatusOK,
+		Payload:    payload,
+	})
+	defer srv.Close()
+
+	client := analytics.NewClient(mockConfig(srv.Server.URL))
+	resp, err := client.FetchGeneralAnalytics(context.Background(), &analytics.MessagingRequest{
+		Start:       1543543200,
+		End:         1544148000,
+		Granularity: analytics.GranularityDay,
+	})
+	test.AssertNoError(t, "FetchGeneralAnalytics failed", err)
+
+	if resp.Analytics == nil {
+		t.Fatal("expected analytics data, got nil")
+	}
+	if len(resp.Analytics.DataPoints) != 1 {
+		t.Fatalf("expected 1 data point, got %d", len(resp.Analytics.DataPoints))
+	}
+
+	reqs := srv.GetRequests()
+	if len(reqs) != 1 {
+		t.Fatalf("expected 1 request, got %d", len(reqs))
+	}
+	r := reqs[0]
+	if r.Method != http.MethodGet {
+		t.Errorf("expected GET, got %s", r.Method)
+	}
+	wantPath := "/v25.0/102290129340398"
+	if r.Path != wantPath {
+		t.Errorf("expected path %s, got %s", wantPath, r.Path)
+	}
+	if fields := r.QueryParams.Get("fields"); fields == "" {
+		t.Error("expected fields query param, got empty")
+	}
+}
+
+func TestFetchConversationAnalytics_MockServer(t *testing.T) {
+	t.Parallel()
+
+	payload, _ := json.Marshal(map[string]any{
+		"conversation_analytics": map[string]any{
+			"data": []map[string]any{
+				{
+					"data_points": []map[string]any{
+						{
+							"start":                  1685602800,
+							"end":                    1688194800,
+							"conversation":           1558,
+							"phone_number":           "15550458206",
+							"country":                "US",
+							"conversation_type":      "REGULAR",
+							"conversation_direction": "UNKNOWN",
+							"conversation_category":  "AUTHENTICATION",
+							"cost":                   15.58,
+						},
+					},
+				},
+			},
+		},
+		"id": "102290129340398",
+	})
+
+	srv := test.NewMockServer(test.MockBehavior{
+		StatusCode: http.StatusOK,
+		Payload:    payload,
+	})
+	defer srv.Close()
+
+	client := analytics.NewClient(mockConfig(srv.Server.URL))
+	resp, err := client.FetchConversationAnalytics(context.Background(), &analytics.ConversationalRequest{
+		Start:       1685602800,
+		End:         1688194800,
+		Granularity: analytics.GranularityMonthly,
+		Options: []analytics.ConversationalQueryParamsOption{
+			analytics.WithConversationalDimensions(
+				analytics.DimensionConversationCategory,
+				analytics.DimensionConversationType,
+				analytics.DimensionCountry,
+				analytics.DimensionPhone,
+			),
+		},
+	})
+	test.AssertNoError(t, "FetchConversationAnalytics failed", err)
+
+	if resp.ConversationAnalytics == nil {
+		t.Fatal("expected conversation analytics data, got nil")
+	}
+
+	reqs := srv.GetRequests()
+	r := reqs[0]
+	if r.Method != http.MethodGet {
+		t.Errorf("expected GET, got %s", r.Method)
+	}
+}
+
+func TestFetchPricingAnalytics_MockServer(t *testing.T) {
+	t.Parallel()
+
+	payload, _ := json.Marshal(map[string]any{
+		"pricing_analytics": map[string]any{
+			"data": []map[string]any{
+				{
+					"data_points": []map[string]any{
+						{
+							"start":            1748761200,
+							"end":              1748847600,
+							"country":          "US",
+							"pricing_type":     "REGULAR",
+							"pricing_category": "MARKETING",
+							"tier":             "0:MAX",
+							"volume":           4,
+							"cost":             40,
+						},
+					},
+				},
+			},
+		},
+		"id": "102290129340398",
+	})
+
+	srv := test.NewMockServer(test.MockBehavior{
+		StatusCode: http.StatusOK,
+		Payload:    payload,
+	})
+	defer srv.Close()
+
+	client := analytics.NewClient(mockConfig(srv.Server.URL))
+	resp, err := client.FetchPricingAnalytics(context.Background(), &analytics.PricingRequest{
+		Start:       1748761200,
+		End:         1749687703,
+		Granularity: analytics.GranularityDaily,
+	})
+	test.AssertNoError(t, "FetchPricingAnalytics failed", err)
+
+	if resp.PricingAnalytics == nil {
+		t.Fatal("expected pricing analytics data, got nil")
+	}
+
+	reqs := srv.GetRequests()
+	r := reqs[0]
+	if r.Method != http.MethodGet {
+		t.Errorf("expected GET, got %s", r.Method)
+	}
+}
+
+func TestFetchCallAnalytics_MockServer(t *testing.T) {
+	t.Parallel()
+
+	payload, _ := json.Marshal(map[string]any{
+		"call_analytics": map[string]any{
+			"granularity": "DAILY",
+			"directions":  "USER_INITIATED",
+			"data_points": []map[string]any{
+				{
+					"start":            1765958400,
+					"end":              1766044800,
+					"cost":             0.47795,
+					"count":            35,
+					"average_duration": 106,
+				},
+			},
+		},
+		"id": "102290129340398",
+	})
+
+	srv := test.NewMockServer(test.MockBehavior{
+		StatusCode: http.StatusOK,
+		Payload:    payload,
+	})
+	defer srv.Close()
+
+	client := analytics.NewClient(mockConfig(srv.Server.URL))
+	resp, err := client.FetchCallAnalytics(context.Background(), &analytics.CallAnalyticsRequest{
+		Start:       1759302000,
+		End:         1767168000,
+		Granularity: analytics.GranularityDaily,
+		Options: []analytics.CallAnalyticsQueryParamsOption{
+			analytics.WithCallDirections(analytics.CallDirectionUserInitiated),
+		},
+	})
+	test.AssertNoError(t, "FetchCallAnalytics failed", err)
+
+	if resp.CallAnalytics == nil {
+		t.Fatal("expected call analytics data, got nil")
+	}
+	if len(resp.CallAnalytics.DataPoints) != 1 {
+		t.Fatalf("expected 1 data point, got %d", len(resp.CallAnalytics.DataPoints))
+	}
+	if resp.CallAnalytics.DataPoints[0].Count != 35 {
+		t.Errorf("expected count 35, got %d", resp.CallAnalytics.DataPoints[0].Count)
+	}
+
+	reqs := srv.GetRequests()
+	r := reqs[0]
+	if r.Method != http.MethodGet {
+		t.Errorf("expected GET, got %s", r.Method)
+	}
+	wantPath := "/v25.0/102290129340398"
+	if r.Path != wantPath {
+		t.Errorf("expected path %s, got %s", wantPath, r.Path)
+	}
+	if fields := r.QueryParams.Get("fields"); fields == "" {
+		t.Error("expected fields query param, got empty")
+	}
+}
+
+func TestBaseResponse_JSONRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	t.Run("MessagingAnalytics", func(t *testing.T) {
+		t.Parallel()
+		response := &analytics.BaseResponse{
+			Messaging: &analytics.MessagingAnalytics{
+				DataPoints: []*analytics.DataPoint{
+					{Start: 1543543200, End: 1543629600, Sent: 196093, Delivered: 179715},
+				},
+			},
+			ID: "102290129340398",
+		}
+		test.AssertJSONRoundTrip(t, "messaging analytics round-trip", response)
+	})
+
+	t.Run("ConversationAnalytics", func(t *testing.T) {
+		t.Parallel()
+		response := &analytics.BaseResponse{
+			Conversational: &analytics.ConversationAnalytics{
+				Data: []*analytics.Data{
+					{
+						DataPoints: []*analytics.DataPoint{
+							{
+								Start: 1685602800, End: 1688194800,
+								Conversation: 1558, PhoneNumber: "15550458206",
+								Country: "US", Cost: 15.58,
+								ConversationCategory: "AUTHENTICATION",
+							},
+						},
+					},
+				},
+			},
+			ID: "102290129340398",
+		}
+		test.AssertJSONRoundTrip(t, "conversation analytics round-trip", response)
+	})
+
+	t.Run("PricingAnalytics", func(t *testing.T) {
+		t.Parallel()
+		response := &analytics.BaseResponse{
+			Pricing: &analytics.PricingAnalytics{
+				Data: []*analytics.Data{
+					{
+						DataPoints: []*analytics.DataPoint{
+							{
+								Start: 1748761200, End: 1748847600,
+								Country: "US", Tier: "0:MAX",
+								PricingType: "REGULAR", PricingCategory: "MARKETING",
+								Volume: 4, Cost: 40,
+							},
+						},
+					},
+				},
+			},
+			ID: "102290129340398",
+		}
+		test.AssertJSONRoundTrip(t, "pricing analytics round-trip", response)
+	})
+
+	t.Run("CallAnalytics", func(t *testing.T) {
+		t.Parallel()
+		response := &analytics.BaseResponse{
+			Call: &analytics.CallAnalytics{
+				Granularity: "DAILY",
+				Directions:  "USER_INITIATED",
+				DataPoints: []*analytics.CallAnalyticsDataPoint{
+					{
+						Start: 1765958400, End: 1766044800,
+						Cost: 0.47795, Count: 35, AverageDuration: 106,
+					},
+				},
+			},
+			ID: "102290129340398",
+		}
+		test.AssertJSONRoundTrip(t, "call analytics round-trip", response)
+	})
+}
+
+func TestCallAnalyticsDataPoint_JSONRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	dp := &analytics.CallAnalyticsDataPoint{
+		Start:           1765958400,
+		End:             1766044800,
+		Cost:            0.47795,
+		Count:           35,
+		AverageDuration: 106,
+	}
+	test.AssertJSONRoundTrip(t, "call analytics data point round-trip", dp)
+}
+
+func TestCallAnalytics_FromDocumentation(t *testing.T) {
+	t.Parallel()
+
+	const docJSON = `{
+		"call_analytics": {
+			"granularity": "DAILY",
+			"directions": "USER_INITIATED",
+			"data_points": [
+				{
+					"start": 1765958400,
+					"end": 1766044800,
+					"cost": 0.47795,
+					"count": 35,
+					"average_duration": 106
+				}
+			]
+		},
+		"id": "102290129340398"
+	}`
+
+	var response analytics.BaseResponse
+	test.AssertJSONUnmarshal(t, "call analytics from docs", docJSON, &response)
+
+	if response.Call == nil {
+		t.Fatal("expected call analytics, got nil")
+	}
+	if len(response.Call.DataPoints) != 1 {
+		t.Fatalf("expected 1 data point, got %d", len(response.Call.DataPoints))
+	}
+	dp := response.Call.DataPoints[0]
+	if dp.Count != 35 {
+		t.Errorf("expected count 35, got %d", dp.Count)
+	}
+	if dp.AverageDuration != 106 {
+		t.Errorf("expected average_duration 106, got %d", dp.AverageDuration)
+	}
+	if dp.Cost != 0.47795 {
+		t.Errorf("expected cost 0.47795, got %f", dp.Cost)
+	}
+	if response.ID != "102290129340398" {
+		t.Errorf("expected ID 102290129340398, got %s", response.ID)
+	}
+}
+
+func TestErrorHandling_MockServer(t *testing.T) {
+	t.Parallel()
+
+	srv := test.NewMockServer(test.MockBehavior{
+		StatusCode: http.StatusInternalServerError,
+		Payload:    []byte(`{"error":{"message":"Internal Server Error"}}`),
+	})
+	defer srv.Close()
+
+	client := analytics.NewClient(mockConfig(srv.Server.URL))
+	_, err := client.FetchGeneralAnalytics(context.Background(), &analytics.MessagingRequest{
+		Start:       1543543200,
+		End:         1544148000,
+		Granularity: analytics.GranularityDay,
+	})
+	if err == nil {
+		t.Fatal("expected error for 500 status, got nil")
+	}
+}

--- a/business/analytics/analytics_test.go
+++ b/business/analytics/analytics_test.go
@@ -124,6 +124,19 @@ func TestQueryParamsString(t *testing.T) {
 			},
 			expected: "pricing_analytics.start(1685602800).end(1688194800).granularity(MONTHLY).phone_numbers([\"19195552584\",\"19195552585\"]).dimensions([\"COUNTRY\",\"PHONE\"]).metric_types([\"COST\"]).pricing_types([\"REGULAR\"]).pricing_categories([\"MARKETING\"])",
 		},
+		// Call Analytics Example
+		{
+			name: "Call Analytics Example",
+			generate: func() *analytics.Request {
+				return analytics.MakeCallAnalyticsQueryParams(
+					1759302000,
+					1767168000,
+					analytics.GranularityDaily,
+					analytics.WithCallDirections(analytics.CallDirectionUserInitiated),
+				)
+			},
+			expected: "call_analytics.start(1759302000).end(1767168000).granularity(DAILY).phone_numbers([]).directions([\"USER_INITIATED\"])",
+		},
 	}
 
 	for _, test := range tests {

--- a/business/analytics/doc.go
+++ b/business/analytics/doc.go
@@ -1,0 +1,124 @@
+//  Copyright 2023 Pius Alfred <me.pius1102@gmail.com>
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+//  and associated documentation files (the "Software"), to deal in the Software without restriction,
+//  including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+//  and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+//  subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all copies or substantial
+//  portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+//  LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+//  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+//  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+// Package analytics provides access to the WhatsApp Business Account Analytics API.
+//
+// The Analytics API offers seven categories of analytics:
+//
+//   - Messaging analytics: number and type of messages sent and delivered
+//     by the phone numbers associated with a WABA.
+//   - Conversation analytics: cost and conversation information for a WABA.
+//   - Pricing analytics: pricing breakdowns for messages delivered within a date range.
+//   - Template analytics: sent, delivered, read, and click metrics for message templates.
+//   - Call analytics: number and type of calls made and received.
+//   - Group analytics: messages sent, delivered, read, and participant activity in groups.
+//   - Template group analytics: metrics for templates within a template group.
+//
+// # Messaging, conversation, pricing, and call analytics
+//
+// These share a common request pattern using the "fields" query parameter.
+// Create a Client with NewClient and call the corresponding Fetch method:
+//
+//	client := analytics.NewClient(config)
+//
+//	// Messaging analytics
+//	resp, _ := client.FetchGeneralAnalytics(ctx, &analytics.MessagingRequest{
+//	    Start: 1700000000, End: 1700604800,
+//	    Granularity: analytics.GranularityDay,
+//	    Options: []analytics.MessagingQueryParamsOption{
+//	        analytics.WithMessagingPhoneNumbers("15551234567"),
+//	    },
+//	})
+//
+//	// Conversation analytics
+//	convResp, _ := client.FetchConversationAnalytics(ctx, &analytics.ConversationalRequest{
+//	    Start: 1700000000, End: 1700604800,
+//	    Granularity: analytics.GranularityMonthly,
+//	    Options: []analytics.ConversationalQueryParamsOption{
+//	        analytics.WithConversationalDimensions(analytics.DimensionCountry),
+//	    },
+//	})
+//
+//	// Pricing analytics
+//	pricingResp, _ := client.FetchPricingAnalytics(ctx, &analytics.PricingRequest{
+//	    Start: 1700000000, End: 1700604800,
+//	    Granularity: analytics.GranularityDaily,
+//	})
+//
+//	// Call analytics
+//	callResp, _ := client.FetchCallAnalytics(ctx, &analytics.CallAnalyticsRequest{
+//	    Start: 1700000000, End: 1700604800,
+//	    Granularity: analytics.GranularityDaily,
+//	    Options: []analytics.CallAnalyticsQueryParamsOption{
+//	        analytics.WithCallDirections(analytics.CallDirectionUserInitiated),
+//	    },
+//	})
+//
+// # Template analytics
+//
+// Template analytics must first be enabled via the Enable method (one-time confirmation).
+// Once enabled, use Fetch to retrieve template metrics:
+//
+//	client.Enable(ctx)
+//	templates, _ := client.Fetch(ctx, &analytics.TemplateAnalyticsRequest{
+//	    Start: 1700000000, End: 1700604800,
+//	    Templates: []string{"template_id_1"},
+//	})
+//
+// Button click tracking can be disabled per-template via DisableButtonClickTracking.
+//
+// # Group and template group analytics
+//
+// These use dedicated endpoints (not the fields parameter). They follow a simpler
+// request pattern:
+//
+//	// Group analytics
+//	groups, _ := client.FetchGroupAnalytics(ctx, &analytics.GroupAnalyticsRequest{
+//	    Start: 1700000000, End: 1700604800,
+//	    GroupIDs: []string{"GROUP_ID"},
+//	    MetricTypes: []analytics.GroupAnalyticsMetricType{
+//	        analytics.GroupMetricSent,
+//	        analytics.GroupMetricRead,
+//	    },
+//	})
+//
+//	// Template group analytics
+//	tgResp, _ := client.FetchTemplateGroupAnalytics(ctx,
+//	    &analytics.TemplateGroupAnalyticsRequest{
+//	        Start: 1700000000, End: 1700604800,
+//	        TemplateGroupIDs: []string{"template_group_id"},
+//	    })
+//
+// # Multi-tenant usage
+//
+// All BaseClient methods accept a per-call config for dynamic credential rotation.
+// The high-level Client methods delegate to these, passing their fixed config.
+//
+// # Limitations
+//
+//   - The maximum lookback window for messaging, conversation, and pricing analytics
+//     is 1 year (as of December 1, 2025).
+//   - Template and template group analytics have a 90-day lookback window.
+//   - Group analytics has a 90-day lookback window.
+//   - Template IDs: maximum 10 per request.
+//   - Template group IDs: maximum 10 per request.
+//   - Group IDs: maximum 1 per request.
+//   - Button click analytics are only available for templates categorized as
+//     MARKETING or UTILITY.
+//   - COST metrics are not returned for WABAs that share a Solution Partner's
+//     credit line.
+package analytics

--- a/business/analytics/group_analytics.go
+++ b/business/analytics/group_analytics.go
@@ -1,0 +1,127 @@
+//  Copyright 2023 Pius Alfred <me.pius1102@gmail.com>
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+//  and associated documentation files (the "Software"), to deal in the Software without restriction,
+//  including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+//  and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+//  subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all copies or substantial
+//  portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+//  LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+//  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+//  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+package analytics
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/piusalfred/whatsapp/config"
+	whttp "github.com/piusalfred/whatsapp/pkg/http"
+)
+
+// GroupAnalyticsMetricType represents the type of metric for group analytics.
+type GroupAnalyticsMetricType string
+
+const (
+	GroupMetricSent               GroupAnalyticsMetricType = "SENT"
+	GroupMetricDelivered          GroupAnalyticsMetricType = "DELIVERED"
+	GroupMetricRead               GroupAnalyticsMetricType = "READ"
+	GroupMetricParticipantsJoined GroupAnalyticsMetricType = "PARTICIPANTS_JOINED"
+	GroupMetricParticipantsLeft   GroupAnalyticsMetricType = "PARTICIPANTS_LEFT"
+)
+
+type (
+	// GroupAnalyticsRequest is the user-facing request for group analytics.
+	GroupAnalyticsRequest struct {
+		Start       int64
+		End         int64
+		GroupIDs    []string
+		MetricTypes []GroupAnalyticsMetricType
+	}
+
+	// GroupAnalyticsResponse contains the group analytics data returned by the API.
+	GroupAnalyticsResponse struct {
+		Data   []GroupAnalyticsData `json:"data,omitempty"`
+		Paging *whttp.Paging        `json:"paging,omitempty"`
+	}
+
+	// GroupAnalyticsData holds a set of data points for a given granularity.
+	GroupAnalyticsData struct {
+		Granularity string                    `json:"granularity,omitempty"`
+		DataPoints  []GroupAnalyticsDataPoint `json:"data_points,omitempty"`
+	}
+
+	// GroupAnalyticsDataPoint represents a single data point in group analytics.
+	GroupAnalyticsDataPoint struct {
+		GroupID   string `json:"group_id,omitempty"`
+		Start     int64  `json:"start,omitempty"`
+		End       int64  `json:"end,omitempty"`
+		Sent      int64  `json:"sent,omitempty"`
+		Delivered int64  `json:"delivered,omitempty"`
+		Read      int64  `json:"read,omitempty"`
+		Joined    int64  `json:"joined,omitempty"`
+		Left      int64  `json:"left,omitempty"`
+	}
+)
+
+// ErrInvalidGroupIDs is returned when the group IDs slice is empty or exceeds the maximum.
+var ErrInvalidGroupIDs = errors.New("invalid number of group IDs")
+
+// FetchGroupAnalytics retrieves group analytics for the specified groups within the given date range.
+func (c *Client) FetchGroupAnalytics(ctx context.Context, params *GroupAnalyticsRequest) (
+	*GroupAnalyticsResponse, error,
+) {
+	return c.sender.FetchGroupAnalytics(ctx, c.config, params)
+}
+
+// FetchGroupAnalytics retrieves group analytics for the specified groups within the given date range.
+// This is the multi-tenant variant that accepts a per-call config.
+func (bc *BaseClient) FetchGroupAnalytics(ctx context.Context, conf *config.Config,
+	params *GroupAnalyticsRequest,
+) (*GroupAnalyticsResponse, error) {
+	queryParams := map[string]string{}
+
+	queryParams["start"] = strconv.FormatInt(params.Start, 10)
+	queryParams["end"] = strconv.FormatInt(params.End, 10)
+	queryParams["granularity"] = GranularityDaily.String()
+
+	if len(params.GroupIDs) == 0 || len(params.GroupIDs) > 1 {
+		return nil, fmt.Errorf("%w: count: %d: must be exactly 1",
+			ErrInvalidGroupIDs, len(params.GroupIDs))
+	}
+	queryParams["group_ids"] = formatArray(params.GroupIDs, quoteString)
+
+	if len(params.MetricTypes) > 0 {
+		metricTypes := make([]string, len(params.MetricTypes))
+		for i, m := range params.MetricTypes {
+			metricTypes[i] = string(m)
+		}
+		queryParams["metric_types"] = formatArray(metricTypes, quoteString)
+	}
+
+	b := whttp.NewRequestBuilder(http.MethodGet, conf.BaseURL).
+		Auth(conf.AuthConfig()).
+		Type(whttp.RequestTypeFetchGroupAnalytics).
+		Endpoints(conf.APIVersion, conf.BusinessAccountID, "group_analytics").
+		QueryParams(queryParams)
+
+	request := whttp.BuildRequest(b, (*BaseRequest)(nil))
+
+	response := &GroupAnalyticsResponse{}
+	decoder := whttp.NewResponseCapturer(whttp.ResponseDecoderJSON(response, whttp.DecodeOptionsStrict()))
+
+	if err := bc.BaseClient.Send(ctx, request, decoder); err != nil {
+		return nil, fmt.Errorf("fetch group analytics: %w", err)
+	}
+
+	return response, nil
+}

--- a/business/analytics/group_analytics_test.go
+++ b/business/analytics/group_analytics_test.go
@@ -1,0 +1,196 @@
+//  Copyright 2023 Pius Alfred <me.pius1102@gmail.com>
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+//  and associated documentation files (the "Software"), to deal in the Software without restriction,
+//  including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+//  and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+//  subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all copies or substantial
+//  portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+//  LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+//  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+//  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+package analytics_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/piusalfred/whatsapp/business/analytics"
+	"github.com/piusalfred/whatsapp/internal/test"
+)
+
+func TestFetchGroupAnalytics_MockServer(t *testing.T) {
+	t.Parallel()
+
+	payload, _ := json.Marshal(map[string]any{
+		"data": []map[string]any{
+			{
+				"granularity": "DAILY",
+				"data_points": []map[string]any{
+					{
+						"group_id":  "GROUP_ID",
+						"start":     1685548801,
+						"end":       1685635200,
+						"sent":      100,
+						"delivered": 250,
+						"read":      200,
+						"joined":    3,
+						"left":      1,
+					},
+				},
+			},
+		},
+		"paging": map[string]any{
+			"cursors": map[string]string{
+				"before": "MAZDZD",
+				"after":  "MjQZD",
+			},
+		},
+	})
+
+	srv := test.NewMockServer(test.MockBehavior{
+		StatusCode: http.StatusOK,
+		Payload:    payload,
+	})
+	defer srv.Close()
+
+	client := analytics.NewClient(mockConfig(srv.Server.URL))
+	resp, err := client.FetchGroupAnalytics(context.Background(), &analytics.GroupAnalyticsRequest{
+		Start:    1764662400,
+		End:      1764921600,
+		GroupIDs: []string{"GROUP_ID"},
+		MetricTypes: []analytics.GroupAnalyticsMetricType{
+			analytics.GroupMetricSent,
+			analytics.GroupMetricDelivered,
+			analytics.GroupMetricRead,
+			analytics.GroupMetricParticipantsJoined,
+			analytics.GroupMetricParticipantsLeft,
+		},
+	})
+	test.AssertNoError(t, "FetchGroupAnalytics failed", err)
+
+	if len(resp.Data) != 1 {
+		t.Fatalf("expected 1 data entry, got %d", len(resp.Data))
+	}
+	if len(resp.Data[0].DataPoints) != 1 {
+		t.Fatalf("expected 1 data point, got %d", len(resp.Data[0].DataPoints))
+	}
+	dp := resp.Data[0].DataPoints[0]
+	if dp.GroupID != "GROUP_ID" {
+		t.Errorf("expected group_id GROUP_ID, got %s", dp.GroupID)
+	}
+	if dp.Sent != 100 {
+		t.Errorf("expected sent 100, got %d", dp.Sent)
+	}
+	if dp.Joined != 3 {
+		t.Errorf("expected joined 3, got %d", dp.Joined)
+	}
+	if dp.Left != 1 {
+		t.Errorf("expected left 1, got %d", dp.Left)
+	}
+
+	reqs := srv.GetRequests()
+	r := reqs[0]
+	if r.Method != http.MethodGet {
+		t.Errorf("expected GET, got %s", r.Method)
+	}
+	wantPath := "/v25.0/102290129340398/group_analytics"
+	if r.Path != wantPath {
+		t.Errorf("expected path %s, got %s", wantPath, r.Path)
+	}
+}
+
+func TestGroupAnalytics_InvalidGroupIDs(t *testing.T) {
+	t.Parallel()
+
+	client := analytics.NewClient(mockConfig("https://graph.facebook.com"))
+
+	_, err := client.FetchGroupAnalytics(context.Background(), &analytics.GroupAnalyticsRequest{
+		Start:    1764662400,
+		End:      1764921600,
+		GroupIDs: nil,
+	})
+	if err == nil {
+		t.Fatal("expected error for empty group IDs, got nil")
+	}
+
+	_, err = client.FetchGroupAnalytics(context.Background(), &analytics.GroupAnalyticsRequest{
+		Start:    1764662400,
+		End:      1764921600,
+		GroupIDs: []string{"ID1", "ID2"},
+	})
+	if err == nil {
+		t.Fatal("expected error for multiple group IDs, got nil")
+	}
+}
+
+func TestGroupAnalyticsDataPoint_JSONRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	dp := &analytics.GroupAnalyticsDataPoint{
+		GroupID:   "GROUP_ID",
+		Start:     1685548801,
+		End:       1685635200,
+		Sent:      100,
+		Delivered: 250,
+		Read:      200,
+		Joined:    3,
+		Left:      1,
+	}
+	test.AssertJSONRoundTrip(t, "group analytics data point round-trip", dp)
+}
+
+func TestGroupAnalytics_FromDocumentation(t *testing.T) {
+	t.Parallel()
+
+	const docJSON = `{
+		"data": [
+			{
+				"granularity": "DAILY",
+				"data_points": [
+					{
+						"group_id": "GROUP_ID",
+						"start": 1685548801,
+						"end": 1685635200,
+						"sent": 100,
+						"delivered": 250,
+						"read": 200,
+						"joined": 3,
+						"left": 1
+					}
+				]
+			}
+		],
+		"paging": {
+			"cursors": {
+				"before": "MAZDZD",
+				"after": "MjQZD"
+			}
+		}
+	}`
+
+	var response analytics.GroupAnalyticsResponse
+	test.AssertJSONUnmarshal(t, "group analytics from docs", docJSON, &response)
+
+	if len(response.Data) != 1 {
+		t.Fatalf("expected 1 data entry, got %d", len(response.Data))
+	}
+	if len(response.Data[0].DataPoints) != 1 {
+		t.Fatalf("expected 1 data point, got %d", len(response.Data[0].DataPoints))
+	}
+	dp := response.Data[0].DataPoints[0]
+	if dp.Sent != 100 {
+		t.Errorf("expected sent 100, got %d", dp.Sent)
+	}
+	if dp.Joined != 3 {
+		t.Errorf("expected joined 3, got %d", dp.Joined)
+	}
+}

--- a/business/analytics/template_group_analytics.go
+++ b/business/analytics/template_group_analytics.go
@@ -1,0 +1,117 @@
+//  Copyright 2023 Pius Alfred <me.pius1102@gmail.com>
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+//  and associated documentation files (the "Software"), to deal in the Software without restriction,
+//  including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+//  and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+//  subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all copies or substantial
+//  portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+//  LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+//  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+//  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+package analytics
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/piusalfred/whatsapp/config"
+	whttp "github.com/piusalfred/whatsapp/pkg/http"
+)
+
+type (
+	// TemplateGroupAnalyticsRequest is the user-facing request for template group analytics.
+	TemplateGroupAnalyticsRequest struct {
+		Start            int64
+		End              int64
+		TemplateGroupIDs []string
+		MetricTypes      []string
+	}
+
+	// TemplateGroupAnalyticsResponse contains the template group analytics data returned by the API.
+	TemplateGroupAnalyticsResponse struct {
+		Data   []TemplateGroupAnalyticsData `json:"data,omitempty"`
+		Paging *whttp.Paging                `json:"paging,omitempty"`
+	}
+
+	// TemplateGroupAnalyticsData holds a set of data points for a given granularity.
+	TemplateGroupAnalyticsData struct {
+		Granularity string                            `json:"granularity,omitempty"`
+		DataPoints  []TemplateGroupAnalyticsDataPoint `json:"data_points,omitempty"`
+	}
+
+	// TemplateGroupAnalyticsDataPoint represents a single data point in template group analytics.
+	TemplateGroupAnalyticsDataPoint struct {
+		TemplateGroupID string               `json:"template_group_id,omitempty"`
+		Start           int64                `json:"start,omitempty"`
+		End             int64                `json:"end,omitempty"`
+		Sent            int64                `json:"sent,omitempty"`
+		Delivered       int64                `json:"delivered,omitempty"`
+		Read            int64                `json:"read,omitempty"`
+		Clicked         []TemplateClicked    `json:"clicked,omitempty"`
+		Cost            []TemplateCostMetric `json:"cost,omitempty"`
+	}
+)
+
+// ErrInvalidTemplateGroupIDs is returned when the template group IDs slice is empty
+// or exceeds the maximum of 10.
+var ErrInvalidTemplateGroupIDs = errors.New("invalid number of template group IDs")
+
+// FetchTemplateGroupAnalytics retrieves template group analytics for the specified
+// template groups within the given date range.
+func (c *Client) FetchTemplateGroupAnalytics(ctx context.Context,
+	params *TemplateGroupAnalyticsRequest,
+) (*TemplateGroupAnalyticsResponse, error) {
+	return c.sender.FetchTemplateGroupAnalytics(ctx, c.config, params)
+}
+
+// FetchTemplateGroupAnalytics retrieves template group analytics for the specified
+// template groups within the given date range.
+// This is the multi-tenant variant that accepts a per-call config.
+func (bc *BaseClient) FetchTemplateGroupAnalytics(ctx context.Context, conf *config.Config,
+	params *TemplateGroupAnalyticsRequest,
+) (*TemplateGroupAnalyticsResponse, error) {
+	queryParams := map[string]string{}
+
+	queryParams["start"] = strconv.FormatInt(params.Start, 10)
+	queryParams["end"] = strconv.FormatInt(params.End, 10)
+	queryParams["granularity"] = GranularityDaily.String()
+
+	if len(params.TemplateGroupIDs) > 0 && len(params.TemplateGroupIDs) <= 10 {
+		queryParams["template_group_ids"] = "[" + strings.Join(params.TemplateGroupIDs, ",") + "]"
+	} else {
+		return nil, fmt.Errorf("%w: count: %d: should be >0 and < 11",
+			ErrInvalidTemplateGroupIDs, len(params.TemplateGroupIDs))
+	}
+
+	if len(params.MetricTypes) > 0 {
+		queryParams["metric_types"] = strings.Join(params.MetricTypes, ",")
+	}
+
+	b := whttp.NewRequestBuilder(http.MethodGet, conf.BaseURL).
+		Auth(conf.AuthConfig()).
+		Type(whttp.RequestTypeFetchTemplateGroupAnalytics).
+		Endpoints(conf.APIVersion, conf.BusinessAccountID, "template_group_analytics").
+		QueryParams(queryParams)
+
+	request := whttp.BuildRequest(b, (*BaseRequest)(nil))
+
+	response := &TemplateGroupAnalyticsResponse{}
+	decoder := whttp.NewResponseCapturer(whttp.ResponseDecoderJSON(response, whttp.DecodeOptionsStrict()))
+
+	if err := bc.BaseClient.Send(ctx, request, decoder); err != nil {
+		return nil, fmt.Errorf("fetch template group analytics: %w", err)
+	}
+
+	return response, nil
+}

--- a/business/analytics/template_group_analytics_test.go
+++ b/business/analytics/template_group_analytics_test.go
@@ -1,0 +1,226 @@
+//  Copyright 2023 Pius Alfred <me.pius1102@gmail.com>
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+//  and associated documentation files (the "Software"), to deal in the Software without restriction,
+//  including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+//  and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+//  subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all copies or substantial
+//  portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+//  LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+//  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+//  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+//  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+package analytics_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/piusalfred/whatsapp/business/analytics"
+	"github.com/piusalfred/whatsapp/internal/test"
+)
+
+func TestFetchTemplateGroupAnalytics_MockServer(t *testing.T) {
+	t.Parallel()
+
+	payload, _ := json.Marshal(map[string]any{
+		"data": []map[string]any{
+			{
+				"granularity": "DAILY",
+				"data_points": []map[string]any{
+					{
+						"template_group_id": "1044106240855852",
+						"start":             1739491200,
+						"end":               1739577600,
+						"sent":              1460,
+						"delivered":         1460,
+						"read":              1399,
+					},
+				},
+			},
+		},
+		"paging": map[string]any{
+			"cursors": map[string]string{
+				"before": "MAZDZD",
+				"after":  "MjQZD",
+			},
+		},
+	})
+
+	srv := test.NewMockServer(test.MockBehavior{
+		StatusCode: http.StatusOK,
+		Payload:    payload,
+	})
+	defer srv.Close()
+
+	client := analytics.NewClient(mockConfig(srv.Server.URL))
+	resp, err := client.FetchTemplateGroupAnalytics(context.Background(),
+		&analytics.TemplateGroupAnalyticsRequest{
+			Start:            1738465116,
+			End:              1739559516,
+			TemplateGroupIDs: []string{"1044106240855852"},
+			MetricTypes:      []string{"sent", "delivered", "read"},
+		})
+	test.AssertNoError(t, "FetchTemplateGroupAnalytics failed", err)
+
+	if len(resp.Data) != 1 {
+		t.Fatalf("expected 1 data entry, got %d", len(resp.Data))
+	}
+	if len(resp.Data[0].DataPoints) != 1 {
+		t.Fatalf("expected 1 data point, got %d", len(resp.Data[0].DataPoints))
+	}
+	dp := resp.Data[0].DataPoints[0]
+	if dp.TemplateGroupID != "1044106240855852" {
+		t.Errorf("expected template_group_id 1044106240855852, got %s", dp.TemplateGroupID)
+	}
+	if dp.Sent != 1460 {
+		t.Errorf("expected sent 1460, got %d", dp.Sent)
+	}
+
+	reqs := srv.GetRequests()
+	r := reqs[0]
+	if r.Method != http.MethodGet {
+		t.Errorf("expected GET, got %s", r.Method)
+	}
+	wantPath := "/v25.0/102290129340398/template_group_analytics"
+	if r.Path != wantPath {
+		t.Errorf("expected path %s, got %s", wantPath, r.Path)
+	}
+}
+
+func TestTemplateGroupAnalytics_InvalidGroupIDs(t *testing.T) {
+	t.Parallel()
+
+	client := analytics.NewClient(mockConfig("https://graph.facebook.com"))
+
+	_, err := client.FetchTemplateGroupAnalytics(context.Background(),
+		&analytics.TemplateGroupAnalyticsRequest{
+			Start:            1738465116,
+			End:              1739559516,
+			TemplateGroupIDs: nil,
+		})
+	if err == nil {
+		t.Fatal("expected error for empty template group IDs, got nil")
+	}
+}
+
+func TestTemplateGroupAnalyticsDataPoint_JSONRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	dp := &analytics.TemplateGroupAnalyticsDataPoint{
+		TemplateGroupID: "1044106240855852",
+		Start:           1739491200,
+		End:             1739577600,
+		Sent:            1460,
+		Delivered:       1460,
+		Read:            1399,
+	}
+	test.AssertJSONRoundTrip(t, "template group analytics data point round-trip", dp)
+}
+
+func TestTemplateGroupAnalytics_FromDocumentation(t *testing.T) {
+	t.Parallel()
+
+	const docJSON = `{
+		"data": [
+			{
+				"granularity": "DAILY",
+				"data_points": [
+					{
+						"template_group_id": "1044106240855852",
+						"start": 1739491200,
+						"end": 1739577600,
+						"sent": 1460,
+						"delivered": 1460,
+						"read": 1399
+					}
+				]
+			}
+		],
+		"paging": {
+			"cursors": {
+				"before": "MAZDZD",
+				"after": "MjQZD"
+			}
+		}
+	}`
+
+	var response analytics.TemplateGroupAnalyticsResponse
+	test.AssertJSONUnmarshal(t, "template group analytics from docs", docJSON, &response)
+
+	if len(response.Data) != 1 {
+		t.Fatalf("expected 1 data entry, got %d", len(response.Data))
+	}
+	if len(response.Data[0].DataPoints) != 1 {
+		t.Fatalf("expected 1 data point, got %d", len(response.Data[0].DataPoints))
+	}
+	dp := response.Data[0].DataPoints[0]
+	if dp.TemplateGroupID != "1044106240855852" {
+		t.Errorf("expected template_group_id 1044106240855852, got %s", dp.TemplateGroupID)
+	}
+	if dp.Sent != 1460 {
+		t.Errorf("expected sent 1460, got %d", dp.Sent)
+	}
+}
+
+func TestTemplateGroupAnalytics_WithCostAndClicks(t *testing.T) {
+	t.Parallel()
+
+	const docJSON = `{
+		"data": [
+			{
+				"granularity": "DAILY",
+				"data_points": [
+					{
+						"template_group_id": "1044106240855852",
+						"start": 1739491200,
+						"end": 1739577600,
+						"sent": 100,
+						"delivered": 95,
+						"read": 80,
+						"clicked": [
+							{
+								"type": "url_button",
+								"button_content": "Learn More",
+								"count": 50
+							}
+						],
+						"cost": [
+							{
+								"type": "amount_spent",
+								"value": 5.25
+							}
+						]
+					}
+				]
+			}
+		]
+	}`
+
+	var response analytics.TemplateGroupAnalyticsResponse
+	test.AssertJSONUnmarshal(t, "template group analytics with cost and clicks", docJSON, &response)
+
+	if len(response.Data) != 1 {
+		t.Fatalf("expected 1 data entry, got %d", len(response.Data))
+	}
+	dp := response.Data[0].DataPoints[0]
+	if len(dp.Clicked) != 1 {
+		t.Fatalf("expected 1 clicked entry, got %d", len(dp.Clicked))
+	}
+	if dp.Clicked[0].Count != 50 {
+		t.Errorf("expected clicked count 50, got %d", dp.Clicked[0].Count)
+	}
+	if len(dp.Cost) != 1 {
+		t.Fatalf("expected 1 cost entry, got %d", len(dp.Cost))
+	}
+	if dp.Cost[0].Value != 5.25 {
+		t.Errorf("expected cost value 5.25, got %f", dp.Cost[0].Value)
+	}
+}

--- a/pkg/http/request_type.go
+++ b/pkg/http/request_type.go
@@ -105,6 +105,10 @@ const (
 	RequestTypeEditTemplate
 	RequestTypeDeleteTemplate
 
+	RequestTypeFetchCallAnalytics
+	RequestTypeFetchGroupAnalytics
+	RequestTypeFetchTemplateGroupAnalytics
+
 	// Sentinel (NOT a real request type): keep this last for testing purposes.
 	requestTypeCount
 )
@@ -195,6 +199,9 @@ var requestTypeStrings = [...]string{ //nolint:gochecknoglobals // immutable str
 	"get_template",
 	"edit_template",
 	"delete_template",
+	"fetch_call_analytics",
+	"fetch_group_analytics",
+	"fetch_template_group_analytics",
 }
 
 func (r RequestType) Name() string {


### PR DESCRIPTION
- Add call analytics endpoint (FetchCallAnalytics) with CallDirection types
- Add group analytics endpoint (FetchGroupAnalytics) with GroupAnalyticsMetricType
- Add template group analytics endpoint (FetchTemplateGroupAnalytics)
- Fix ConversationalTypeFreeEntry to use FREE_ENTRY_POINT (was FREE_ENTRY)
- Add missing constants: MetricType (VOLUME, COUNT, AVERAGE_DURATION), Dimension (PRICING_CATEGORY, PRICING_TYPE, TIER, DIRECTION), PricingCategory (MARKETING_LITE, REFERRAL_CONVERSION), ConversationalDirection (UNKNOWN)
- Add Tier field to DataPoint for pricing analytics tier info
- Add CloseIdleConnections method to Client
- Add package doc.go with comprehensive usage documentation
- Refactor QueryParamsString to reduce cognitive complexity
- Add 3 new RequestType constants for new endpoints
- Add comprehensive tests: MockServer integration, JSON round-trip, documentation JSON parsing, error handling (28 tests total)